### PR TITLE
衝突判定の改善、wiimoteの接続方法の変更

### DIFF
--- a/data/src/client/main/Game.cpp
+++ b/data/src/client/main/Game.cpp
@@ -32,6 +32,8 @@ Prs Game::prs;
 
 char Game::command;
 bool Start_BGM = false;
+bool Game::collision = false;
+bool Game::isWiifit = false;
 
 cwiid_wiimote_t *wiimote = NULL; //WiiBalanceBoardの情報
 
@@ -62,6 +64,7 @@ bool Game::Initialize(int argc, char *argv[])
 	{
 		serverName = argv[1];
 		str2ba(argv[3], &bdaddr); //要調整必要、引数の取ったアドレスで渡す
+		isWiifit = true;
 	}
 
 	/* サーバーとの接続 */
@@ -102,6 +105,12 @@ bool Game::Initialize(int argc, char *argv[])
 	sound->Sound_Initialize();
 
 	//ここからwiifitの初期化
+
+	if (isWiifit == false)
+	{
+		fputs("WiiFit is unable to connect\n", stderr);
+		return true;
+	}
 
 	if ((wiimote = cwiid_open(&bdaddr, 0)) == NULL) //コネクトに必要な関数
 	{
@@ -348,8 +357,9 @@ void Game::UpdateGame()
 			{
 				mCommand->PlayerPos[clientID].x -= Client_command::Back_speed * Player_difference[clientID].x * deltaTime * 0.5f;
 				mCommand->PlayerPos[clientID].y -= Client_command::Back_speed * Player_difference[clientID].y * deltaTime * 0.5f;
+				collision = true;
 			}
-			else
+			else if (collision == false)
 			{
 				mCommand->PlayerPos[clientID].x -= Client_command::Back_speed * Collision_difference[clientID].x * deltaTime * 0.5f;
 				mCommand->PlayerPos[clientID].y -= Client_command::Back_speed * Collision_difference[clientID].y * deltaTime * 0.5f;
@@ -364,6 +374,7 @@ void Game::UpdateGame()
 				Client_command::isRepulsion = false;
 				Client_command::Collisioned_oppnent = -1;
 				mCountTimer = 0;
+				collision = false;
 				Sound::Collision_Sound();
 
 				if (Client_command::isCollision == true)
@@ -373,7 +384,8 @@ void Game::UpdateGame()
 					pos.x = mCommand->PlayerPos[clientID].x;
 					pos.y = mCommand->PlayerPos[clientID].y;
 					mPlayer->SetPosition(pos);
-					mRacer[clientID]->SetPosition(pos);
+					//mRacer[clientID]->SetPosition(pos);
+					//Client_command::isCollision = false;
 				}
 			}
 		}
@@ -415,6 +427,7 @@ void Game::UpdateGame()
 			mCommand->isCollision = false;
 			Client_command::isRepulsion = true;
 		}
+
 		if (mCommand->isStart == true)
 		{
 			mPlayer->SetPlayerState(Player::PlayerState::ERunning);

--- a/data/src/client/main/Game.h
+++ b/data/src/client/main/Game.h
@@ -48,6 +48,8 @@ public:
   static int clientID;
   static CONTAINER Player_difference[MAX_CLIENTS];
   static CONTAINER Collision_difference[MAX_CLIENTS];
+  static bool collision;
+  static bool isWiifit;
 
   // Getter
   class Client_net *GetClient_net(void) const { return mNet; }

--- a/data/src/server/main/Server_calculate.cpp
+++ b/data/src/server/main/Server_calculate.cpp
@@ -23,13 +23,23 @@ int Calculate::Player_restitution(CONTAINER Posdata)
     float mv1 = 0;                                             //衝突後の衝突した方の速度
     float mv2 = 0;                                             //衝突後の衝突された方の速度
     float m1 = Collision::PlayerPos[Posdata.Client_id].weight; //衝突した方の質量
-    float e = 0.5f;                                            //0<=e<=1の間の反発係数
+    float e = 0.1f;                                            //0<=e<=1の間の反発係数
 
     mv1 = ((m1 - e * m2) * v1 + (m2 + e * m2) * v2) / (m1 + m2);
-    mv2 = ((m2 - e * m1) * v2 - (m1 + e * m1) * v1) / (m1 + m2);
-    Server_command::Posdata.speed = mv1;
+    mv2 = ((m2 - e * m1) * v2 + (m1 + e * m1) * v1) / (m1 + m2);
+    /*マジックナンバーで処理*/
+    if (mv1 > 170)
+    {
+        mv1 = 165;
+    }
+    if (mv2 > 170)
+    {
+        mv2 = 165;
+    }
+    /***************************************/
+    Server_command::Posdata.speed = mv1 / 2;
 
-    SpeedStorage[Collision::collision_oppnent] = mv2;
+    SpeedStorage[Collision::collision_oppnent] = mv2 / 2;
 
     Collision::Player_Collision_Strage[Collision::collision_oppnent] = 1;
 }


### PR DESCRIPTION
内容：反発したときに衝突した場合、軌道がおかしくなるバグの改善をした。ただし、直ったのではなくあくまで改善したのであってバグは残っているが、以前よりはマシになった。
wiiの接続は端末上で引数を取らないと接続しないようにした。